### PR TITLE
make cursors_path runtime configurable

### DIFF
--- a/cursors.lua
+++ b/cursors.lua
@@ -1,6 +1,6 @@
 local module = {}
 local cursors = {}
-local cursors_path = string.format('%s/.cursors', os.getenv('HOME'))
+module.cursors_path = string.format('%s/.cursors', os.getenv('HOME'))
 
 function set_pos(win)
 	if win.file == nil or win.file.path == nil then return end
@@ -11,7 +11,7 @@ end
 
 function module.start()
 	cursors = {}
-	local f = io.open(cursors_path)
+	local f = io.open(module.cursors_path)
 	if f == nil then return end
 	for line in f:lines() do
 		for k, v in string.gmatch(line, '(.+)%s(%d+)') do
@@ -34,7 +34,7 @@ function module.win_close(win)
 end
 
 function module.quit()
-	local f = io.open(cursors_path, 'w+')
+	local f = io.open(module.cursors_path, 'w+')
 	if f == nil then return end
 	local a = {}
 	for k in pairs(cursors) do table.insert(a, k) end


### PR DESCRIPTION
It would be great to be able to set the history file path without changing the source of vis-cursors.
After this change you can clone vis-cursors into your vis configuration directory and use it in your visrc.lua like this:

```lua
local cursors = require('vis-cursors/cursors')
cursors.cursors_path = 'path/to/your/file'
```
