### PR TITLE
limit the number of "remembered" files

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -50,6 +50,9 @@ local read_cursors = function()
 		end
 	end
 	f:close()
+	if M.maxcursors == 0 then  -- store all files
+		M.maxcursors = n
+	end
 end
 
 local write_cursors = function()


### PR DESCRIPTION
With this PR, the number of file names/positions stored is limited.
Otherwise, the log file will grow indefinitely, storing all files, even the ones that do not exist anymore.