### PR TITLE
ignore files with cursor at the beginning; simplify cursor saving

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -80,6 +80,12 @@ local on_win_close = function(win)
 		end
 	end
 
+	-- ignore files with cursor at the beginning
+	if win.selection.pos == 0 then
+		return
+	end
+
+
 	-- insert current path to top of files
 	table.insert(files, 1, win.file.path)
 


### PR DESCRIPTION
to prevent the need fo buffering, it is skipped entirely and the current state of cursors are immediately saved instead of buffering.

additionally, files with the cursor at the top of the window (default position) will not be saved, saving size 