### PR TITLE
Use string.match instead of string.gmatch when reading/loading db.

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -28,10 +28,9 @@ local function read_files()
 
 	-- read positions per file path
 	for line in file:lines() do
-		for path, pos in string.gmatch(line, '(.+)[,%s](%d+)') do
-			cursors[path] = pos
-			table.insert(files, path)
-		end
+		local path, pos = string.match(line, '^(.+)[,%s](%d+)$')
+		cursors[path] = pos
+		table.insert(files, path)
 	end
 
 	file:close()


### PR DESCRIPTION
renamed read_files() to load_db()
on_init now points to load_db instead of having a wrapper function

Given that the db is a very simple csv and the record is in a single line
string.gmatch was changed to a single string.match because for now csv is simple enough, but if more fields are added, things might break