### PR TITLE
Add patterns to ignore fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,4 +8,6 @@ Set a custom path with `M.path`.
 
 Limit number of files/positions with `M.maxsize` (defaults to `1000`).
 
+Use `M.ignore` to set a list of patterns for paths to leave cursor at top left (defaults to `{ "COMMIT_EDITMSG$", "git%-rebase%-todo$" }` ).
+
 Cursor positions per file are ordered by the last used at the top of `vis-cursors.csv`.

--- a/init.lua
+++ b/init.lua
@@ -14,6 +14,12 @@ local get_default_cache_path = function()
 	return cache_path
 end
 
+-- default ignore patterns
+M.ignore = {
+	"COMMIT_EDITMSG$",
+	"git%-rebase%-todo$",
+}
+
 -- default save path
 M.path = get_default_cache_path()
 
@@ -82,6 +88,12 @@ local on_win_close = function(win)
 		return
 	end
 
+	-- ignore files specified in the ignore field
+	for _, pattern in pairs(M.ignore) do
+		if win.file.path:match(pattern) then
+			return
+		end
+	end
 
 	-- insert current path to top of files
 	table.insert(files, 1, win.file.path)

--- a/init.lua
+++ b/init.lua
@@ -42,6 +42,16 @@ local function read_files()
 	file:close()
 end
 
+-- ignore files specified in the ignore field
+local is_file_ignored = function(path)
+	for _, pattern in pairs(M.ignore) do
+		if path:match(pattern) then
+			return true
+		end
+	end
+	return false
+end
+
 -- read cursors from file on init
 local on_init = function()
 	read_files()
@@ -50,6 +60,10 @@ end
 -- apply cursor pos on win open
 local on_win_open = function(win)
 	if win.file == nil or win.file.path == nil then
+		return
+	end
+
+	if is_file_ignored(win.file.path) then
 		return
 	end
 
@@ -88,11 +102,8 @@ local on_win_close = function(win)
 		return
 	end
 
-	-- ignore files specified in the ignore field
-	for _, pattern in pairs(M.ignore) do
-		if win.file.path:match(pattern) then
-			return
-		end
+	if is_file_ignored(win.file.path) then
+		return
 	end
 
 	-- insert current path to top of files


### PR DESCRIPTION
Hi Erlend,

`vis-cursors` was the first plugin I installed for vis. Thank you!

 - What: This patch enables users to specify a list of patterns for files that vis-cursors will not save cursor state for.
 - Why: When writing a commit message with vis, vis-cursors will move the cursor to where it was for the previous one. The same for a rebase todo. This is slightly annoying. There might be other files/directories for which a user might want the cursor left at the beginning of the file. I used to have something like this in my `.visrc`:

       if
         (win.syntax == 'diff' or win.syntax == 'git-commit')
         and (win.file.name or ''):match('COMMIT_EDITMSG$')
       then
         win.selection.pos = 0
       end

   This patch moves the functionality to where it belongs IMHO. I believe in sensible defaults, and the aforementioned cases are included.

 - How: There's code that decides not to save a position when it's `0`. I added the interpretation of the patterns there. That means two things: 1) startup speed is not affected, and 2) The new behaviour will only be noticed on the second save for a given file. I think this is worth it because no transitional code (with performance cost) will have to be removed after a while, and most users won't really care that much.

Long write-up for a small feature, I know ;)